### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Community/T02_Spring_XD_Hadoop_Twitter.md
+++ b/Community/T02_Spring_XD_Hadoop_Twitter.md
@@ -2,11 +2,11 @@
 
 **This tutorial is from the Community part of tutorial for [Hortonworks Sandbox](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.** 
 
-###Summary
+### Summary
 
 This tutorial will build on the previous tutorial - [13 - Refining and Visualizing Sentiment Data](../Sandbox/T13_Refining_And_Visualizing_Sentiment_Data.md) - by using Spring XD to stream in tweets to HDFS. Once in HDFS, we'll use Apache Hive to process and analyze them, before visualizing in a tool.
 
-##1 - Download and Install Spring XD
+## 1 - Download and Install Spring XD
 Spring XD can be found at [http://spring.io](http://projects.spring.io/spring-xd/). This tutorial uses the 1.0.0.M3 version. Conventions may change in the next release. 
 
 Follow the install instructions and kick up Spring XD with a test stream to make sure it's looking good. 
@@ -24,10 +24,10 @@ That simple instruction should begin showing output in the server terminal windo
 	
 Congrats! Spring XD is running.
 
-##2 - Download and Install Hortonworks Sandbox
+## 2 - Download and Install Hortonworks Sandbox
 The Hortonworks Sandbox environment can be downloaded from [http://hortonworks.com/products/sandbox](http://hortonworks.com/products/sandbox). This tutorial uses the 1.3 version.  Conventions may change in the next release. This tutorial also uses the VirtualBox version of the image.
 
-###Running Sandbox with Bridged Networking
+### Running Sandbox with Bridged Networking
 The current Sandbox uses a NAT adapter with port forwarding by default. This makes it convenient to access Sandbox at 127.0.0.1:8888 but unfortunately, Spring XD appears to locate and attempt to use the internal IP address (in my case that was a fairly standard VirtualBox IP 10.0.2.15).
 As this IP won't resolve, the simplest workaround is to use Bridged Networking so the Sandbox has an IP address on local physical network.
 
@@ -52,22 +52,22 @@ Steps to do this are as follows:
 In my case, local IP was 10.0.0.27 and I could access the Sandbox at 10.0.0.27:8888.
 Check whether you can do the same and then, we can configure SpringXD to use Sandbox.
 
-###Configuring Spring XD to use Hadoop (Hortonworks Sandbox)
+### Configuring Spring XD to use Hadoop (Hortonworks Sandbox)
 **NB: If you have Ambari activated on Sandbox, then both Ambari and Spring XD attempt to use port 8080. This means you'll need to run Spring XD with a different port, for example:** `--httpPort 8090`
 
-####Step 1 - Edit the Hadoop.properties file
+#### Step 1 - Edit the Hadoop.properties file
 
 Edit the file at `XD_HOME\xd\config\hadoop.properties` to enter the namenode config:
 	
 	fs.default.name=hdfs://10.0.0.27:8020
 
-####Step 2 - Spin up the Spring XD Service with Hadoop
+#### Step 2 - Spin up the Spring XD Service with Hadoop
 
 In a terminal window get the server running from the `XD_HOME\XD\` folder:
 
 	./xd-singlenode --hadoopDistro hadoop11
 
-####Step 3 - Spin up the Spring XD Client with Hadoop
+#### Step 3 - Spin up the Spring XD Client with Hadoop
 
 In a separate terminal window, get the shell running from the `XD_HOME\Shell\` folder:
 
@@ -116,7 +116,7 @@ Which you can quickly examine with:
 
 Cool, but not so interesting, so let's get to Twitter.
 
-##3 - Create the Tweet Stream in Spring XD
+## 3 - Create the Tweet Stream in Spring XD
 
 In order to stream in information from Twitter, then you'll need to set-up a [Twitter Developer app](http://dev.twitter.com) so that you can get the necessary keys.
 
@@ -155,7 +155,7 @@ At this point, you can undeploy the stream so we can do some sample analysis:
 	
 We're now done with Spring XD. It's a fun way to pull in a [bunch of data from various sources](http://docs.spring.io/spring-xd/docs/1.0.0.BUILD-SNAPSHOT/reference/html/#sources). We can now switch over to Sandbox.
 
-##4 - Refine the Data using Hive
+## 4 - Refine the Data using Hive
 
 To process and analyze the data, we'll borrow the technique [from the previous tutorial](../Sandbox/T13_Refining_And_Visualizing_Sentiment_Data.md). First of all, we can take a look in the File Browser to see the logs we've ingested.
 
@@ -165,7 +165,7 @@ Next, we need to position the reference files for the analysis. You can follow t
 
 Next, let's run some Hive queries. 
 
-###Create the Tables for the logos, dictionary and time zone map
+### Create the Tables for the logos, dictionary and time zone map
 
 In the [previous tutorial](../Sandbox/T13_Refining_And_Visualizing_Sentiment_Data.md), we had the luxury of pre-formatted files, but in this case, the incoming tweets are stored as JSON, so we need to use a JSON SerDe to process the files into tables. This [project on Github](https://github.com/rcongiu/Hive-JSON-Serde.git) provides a great JSON SerDe. We need to clone it, build it and then move it to the Sandbox. Use the following to build the JAR.
 
@@ -327,6 +327,6 @@ Once this job has completed, then a quick browse of the data in `cyrustweetsanal
 
 ![./images/tutorial-02/screenshot.7.png?raw=true](./images/tutorial-02/screenshot.7.png?raw=true)
 
-##5 - Visualize the Data using Tool X
+## 5 - Visualize the Data using Tool X
 
 We've created the same table definition as in [Tutorial 13](../Sandbox/T13_Refining_And_Visualizing_Sentiment_Data.md), so you could now follow the rest of those instructions to visualize this data in PowerBI and Excel, or you could follow a tutorial for another [visualization tool such as Tableau](http://hortonworks.com/hadoop-tutorial/making-things-tick-with-tableau/).

--- a/Community/T05_Use_HDFS_Explorer_To_Manage_Files_On_The_Hortonworks_Sandbox.md
+++ b/Community/T05_Use_HDFS_Explorer_To_Manage_Files_On_The_Hortonworks_Sandbox.md
@@ -15,7 +15,7 @@ In this tutorial we will walk through how to connect HDFS Explorer to the Horton
 1.  Download and start [Hortonworks Sandbox 2.0](http://hortonworks.com/products/hortonworks-sandbox/#install)
 2.  Download and install [HDFS Explorer](http://bigdata.red-gate.com/hdfs-explorer.html)
 
-###Step one: Enable access to the Hortonworks Sandbox from your local machine.
+### Step one: Enable access to the Hortonworks Sandbox from your local machine.
 In order to access the Hortonworks Sandbox with HDFS Explorer you will need to create an entry in your hosts file. 
 
 To do this launch Notepad [with administrator privileges](http://windows.microsoft.com/en-gb/windows7/how-do-i-run-an-application-once-with-a-full-administrator-access-token).
@@ -38,7 +38,7 @@ Add the following code to the end of the hosts file:
 
 **Note: if you have configured your Sandbox to use a different IP address, then you'll need to change the IP address in the snippet above.**
 
-###Step Two: Connect to your Sandbox in HDFS Explorer.
+### Step Two: Connect to your Sandbox in HDFS Explorer.
 
 
 * Launch HDFS Explorer
@@ -55,7 +55,7 @@ Add the following code to the end of the hosts file:
 
 **Note: HDFS Explorer supports multiple connections. To create additional connections, simply click file > add connection again. **
 
-###Next Steps
+### Next Steps
 Once HDFS Explorer is connected to the Hortonworks Sandbox it can be used to rapidly upload files and data and download query results using the familiar Windows Explorer-like GUI.
 
 

--- a/Community/T06_Java_Hive_Integration_Salary_Delta_Analysis_And_Visualization_Using_JFreeChart.md
+++ b/Community/T06_Java_Hive_Integration_Salary_Delta_Analysis_And_Visualization_Using_JFreeChart.md
@@ -22,13 +22,13 @@ To follow the steps in this tutorial, your computer must have the following item
 2. **JFreeChart Library:** JFreeChart is the open source charting library which we will use for creating graphical charts. Download Location: <http://sourceforge.net/projects/jfreechart/files/latest/download?source=files> \[**Note**: Extract the downloaded JFreeChart archive file and ensure that it contains a "lib" directory\]
 
 ### Steps Involved
-####Eclipse Project Setup
+#### Eclipse Project Setup
 1. Create an Eclipse Java Project with name "HiveJavaIntegration".
 2. Go to Project Properties window and in "Java Build Path" section, click on "Add External Jars"
 3. In the JAR Selection dialog, select all jars in the "lib" directory of Hive and press OK.  This will add all Hive library jars to the eclipse project.
 4. Similarly, add all the jars from the "lib" directory of JFreeChart as well.
 
-####Hortonworks Sandbox - Port Forwarding Setup
+#### Hortonworks Sandbox - Port Forwarding Setup
 By default, the port mapping for the Hive2 service of Hortonworks sandbox is missing in the Virtualbox entries.  Lets go and create that one.
 
 Right click the Virtual Machine in the Virtualbox and select "Settings".
@@ -45,7 +45,7 @@ Add a new entry in the "Port Forwarding Rules" for hive (hive-tcp-2200-10000) as
 
 Now, Hive2 Service can be reached from a java program running in Eclipse.
 
-####Coding the Java Class
+#### Coding the Java Class
 Create a Java class with name "HiveDataFetcher" and following code in it.
 
 ```java
@@ -175,13 +175,13 @@ public class SalaryDifferenceChartPlotter {
 
 Remember to change the "outputFilePath" variable to suit your needs.
 
-####Run and Generate Chart
+#### Run and Generate Chart
 1. Start the Hortonworks Sandbox VM.
 2. After service has started, go to Eclipse, right click on "SalaryDifferenceChartPlotter" java class and select "Run -> As Java Application".
 3. Check if chart has been generated in the output path specified in code.
 
 ![Salary Difference Chart](images/tutorial-06/salary_difference_chart.jpg "Salary Difference Chart")
 
-####Next Steps
+#### Next Steps
 Tweak the code and play around :)
 

--- a/Community/T07_Elasticsearch_Hadoop_Integration.md
+++ b/Community/T07_Elasticsearch_Hadoop_Integration.md
@@ -20,12 +20,12 @@ To follow the steps in this tutorial, your computer must have the following item
 Just download [apache.zip](http://download.elasticsearch.org/hadoop/short-video-1/apache.zip) from Costin Leau [video tutorial](http://www.elasticsearch.org/videos/search-and-analytics-with-hadoop-and-elasticsearch/).
 
 ### Setup
-####Elasticsearch setup
+#### Elasticsearch setup
 
 Launch elasticsearch. We won't enter into details on how Elasticsearch works here as it is not our point. For more information, please refer to [elasticsearch website](http://www.elasticsearch.org/guide/).
 
 
-####Hortonworks Sandbox
+#### Hortonworks Sandbox
 Download and launch the sandbox. It should show a screen like this one : 
 ![Sandbox start screen](images/tutorial-07/sandbox.png)
 

--- a/Community/T08_Java_HBase_Integration_Profession_Analysis_And_Visualization_Using_JFreeChart.md
+++ b/Community/T08_Java_HBase_Integration_Profession_Analysis_And_Visualization_Using_JFreeChart.md
@@ -23,18 +23,18 @@ To follow the steps in this tutorial, your computer must have the following item
 2. **JFreeChart Library:** JFreeChart is the open source charting library which we will use for creating graphical charts. Download Location: <http://sourceforge.net/projects/jfreechart/files/latest/download?source=files> \[**Note**: Extract the downloaded JFreeChart archive file and ensure that it contains a "lib" directory\]
 
 ### Steps Involved
-####Eclipse Project Setup
+#### Eclipse Project Setup
 1. Create an Eclipse Java Project with name "HBaseJavaIntegration".
 2. Go to Project Properties window and in "Java Build Path" section, click on "Add External Jars"
 3. In the JAR Selection dialog, select all jars in the "lib" directory of HBase and press OK.  This will add all HBase library jars to the eclipse project.
 4. Similarly, add all the jars from the "lib" directory of JFreeChart as well.
 
-####Hosts file setup
+#### Hosts file setup
 Add an entry of domain sandbox.hortonworks.com pointing to the IP Address 127.0.0.1 in your hosts file.
 
 In Linux environments, the path of the hosts file is /etc/hosts.  In Windows, the path of the hosts file is %systemroot%\system32\drivers\etc\.
 
-####HBase Table Creation
+#### HBase Table Creation
 1. Launch Hortonworks Sandbox in browser.
 2. Navigate to Hue Shell -> HBase Shell.
 3. Execute the following command.
@@ -44,7 +44,7 @@ create 'professionals','medical-related','writer-related'
 ```
 The above command creates a table with name 'professionals' with two column families namely, 'medical-related' and 'writer-related'.
 
-####What does this example do?
+#### What does this example do?
 In this example, we are trying to do the following things **using a Java Program**.
 
 1. Add 4 doctors of variying specializations into table 'professionals'.  They will have entries in column family "medical-related".
@@ -53,7 +53,7 @@ In this example, we are trying to do the following things **using a Java Program
 4. Scan the table's "medical-related" column family and try to plot a pie chart based on specialization.  Store the pie chart as JPG file.
 5. Scan the table's "writers" column family and try to print all the writers into a text file.  Verify that "Joe",the doctor-writer shows up in the list.
 
-####Coding the Java Class
+#### Coding the Java Class
 Create a Java class with name "HBaseProfessionAnalyser" and following code in it.
 
 ```java
@@ -345,7 +345,7 @@ class Writer {
 
 Remember to change the output file path variables to suit your needs.
 
-####Run and Generate Chart
+#### Run and Generate Chart
 1. Start the Hortonworks Sandbox VM.
 2. After service has started, go to Eclipse, right click on "HBaseProfessionAnalyser" java class and select "Run -> As Java Application".
 3. Check if the writers list text file has been generated.  Verify if "Joe" is also printed there. ![Writers list text file](images/tutorial-08/writers_list_text_file.png "Writers list text file")
@@ -353,6 +353,6 @@ Remember to change the output file path variables to suit your needs.
 
 ![Doctor Specialities Pie Chart](images/tutorial-08/doctor_specialities_pie_chart.jpg "Doctor Specialities Pie Chart")
 
-####Next Steps
+#### Next Steps
 Tweak the code and play around :)
 

--- a/Community/T09_Write_And_Run_Your_Own_MapReduce_Java_Program_Poll_Result_Analysis.md
+++ b/Community/T09_Write_And_Run_Your_Own_MapReduce_Java_Program_Poll_Result_Analysis.md
@@ -27,7 +27,7 @@ To follow the steps in this tutorial, your computer must have the following item
 ### Explanation of the Use Case
 A fictional use case is presented here, in order to enable you to easily understand the functionality and power of Hadoop MapReduce, without finding it overwhelming or boring.
 
-####General Elections in Utopia
+#### General Elections in Utopia
 In the democratic country of Utopia, the General Elections (Polls) for the position of President was conducted some days ago.  About five million Utopian Citizens participated in the elections with full enthusiasm and cast their votes to the candidate whom they think deserves the position.  Because of large population, the elections were conducted in 1000 polling booths, geographically separated, so that a citizen can vote from his nearest booth.
 
 There were five contestants for the post.  The names of the candidates are as follows:  
@@ -59,7 +59,7 @@ Jojo
 You have to announce the results by this evening, before 5 PM.  It is already 10 AM.  As it happens to be, you are a good Java Programmer. Now, roll up your sleeves and follow the instructions to count the votes and announce the results by 5 PM.
 
 ### Instructions
-####Eclipse Project Setup
+#### Eclipse Project Setup
 1. Create an Eclipse Java Project with name `UtopiaVoteCount`.
 2. Go to Project Properties window and in "Java Build Path" section, click on "Add External Jars"
 3. In the JAR Selection dialog, select the following jars from the extracted Hadoop tar.gz file.
@@ -70,7 +70,7 @@ You have to announce the results by this evening, before 5 PM.  It is already 10
 
 ![Eclipse Build Path Settings](images/tutorial-09/eclipse_build_path_settings.png "Eclipse Build Path Settings")
 
-####Code the Mapper Class
+#### Code the Mapper Class
 In the eclipse project created above, create a new Java Class file with name `VoteCountMapper` and write the following code in it.  This will be the Mapper Class.
 
 ```java
@@ -97,7 +97,7 @@ public class VoteCountMapper extends Mapper<Object, Text, Text, IntWritable> {
 }
 
 ```
-####Code the Reducer Class
+#### Code the Reducer Class
 In the eclipse project created above, create a new Java Class file with name `VoteCountReducer` and write the following code in it.  This will be the Reducer Class.
 
 ```java
@@ -123,7 +123,7 @@ public class VoteCountReducer extends Reducer<Text, IntWritable, Text, IntWritab
 }
 ```
 
-####Code the MapReduce Application/Driver Class
+#### Code the MapReduce Application/Driver Class
 In the eclipse project created above, create a new Java Class file with name `VoteCountApplication` and write the following code in it.  This will be the Application/Driver Class.
 
 ```java
@@ -178,7 +178,7 @@ public class VoteCountApplication extends Configured implements Tool{
 }
 ```
 
-####Setting Java Version - Compiler Options
+#### Setting Java Version - Compiler Options
 Hortonworks Sandbox VM contains Java version 6.  So, we need to compile our classes using Java Version 6 in order to avoid Version Mismatch runtime exception.  To ensure compilation using Java Version 6, follow the below instructions.
 
 1. Right-click on the Java Project `UtopiaVoteCount` and click on `Properties` menu option.
@@ -188,7 +188,7 @@ Hortonworks Sandbox VM contains Java version 6.  So, we need to compile our clas
 
 ![Eclipse Java Version Settings](images/tutorial-09/eclipse_java_version_settings.png "Eclipse Java Version Settings")
 
-####Creating a Java Archive (JAR) File
+#### Creating a Java Archive (JAR) File
 To test your application's error scenario, right-click on `VoteCountApplication` class and choose Run as -> Java Application.  This should print the following error message in the eclipse console.
 
 ```
@@ -202,7 +202,7 @@ Now, let us export the Java Project to a JAR file.
 3. In the Launch configuration, choose `UtopiaVoteCount` project.  Choose export destination as ~/Desktop/UtopiaVoteCount.jar. Here, ~ means the user's home directory. Choose "Extract required libraries into generated JAR" option and click on Finish.  Click OK for all the ensuing warning messages.  Ignore if any warnings are displayed after export.
 4. Using a file browser, check if UtopiaVoteCount.jar exists in ~/Desktop directory.
 
-####VirtualBox Shared Folder Settings
+#### VirtualBox Shared Folder Settings
 We are going to setup the directory ~/Desktop to be shared between our Host computer and the Hortonworks Sandbox.  We need this to transfer the UtopiaVoteCount.jar to the Hortonworks Sandbox.
 
 1. Before powering up the Hortonworks Sandbox, open the settings of Hortonworks Sandbox VM.
@@ -216,24 +216,24 @@ Now, you can access your ~/Desktop folder from within Hortonworks Sandbox.
 
 ![Virtualbox Shared Folder Settings](images/tutorial-09/shared_folder_settings.png "Virtualbox Shared Folder Settings")
 
-####Verify Shared Folder Access
+#### Verify Shared Folder Access
 Let us check if you can access the UtopiaVoteCount.jar file present in ~/Desktop folder, from within the Hortonworks Sandbox.
 
 Boot up your Hortonworks Sandbox VM.  In the Virtual machine's window, press `Alt+F5` and login as root/hadoop.
 
 To change to mounted directories, type `cd /media/` and press Enter.  Now, type `ls` and press Enter to bring up a list of shared folders.  This should show `sf_Desktop` as an entry.  This means that you can access ~/Desktop of your computer from within Hortonworks Sandbox VM.
 
-####Copy JAR to hue Home Directory
+#### Copy JAR to hue Home Directory
 We are going to run our MapReduce Job as `hue` user.  So, we need to copy the `UtopiaVoteCount.jar` to that user's home directory `/usr/lib/hue`, with permissions for `hue` to execute the same.
 
 In the command prompt, enter the command `cp /media/sf_Desktop/UtopiaVoteCount.jar /usr/lib/hue/` and press Enter.
 
 Now, enter the command `cd /usr/lib/hue/ ; chmod 777 UtopiaVoteCount.jar` and press Enter.  This will make the JAR file readable and executable by all.
 
-####Test Input Data Setup
+#### Test Input Data Setup
 For our MapReduce job to execute, we need test input data.  The test input data is nothing but a set of files, having multiple lines, one name in each line.  So, go to [File Browser](http://localhost:8000/filebrowser/) and create a directory `VoteCountInput` under `/user/hue` directory.  Inside the directory, create two files booth-1.txt and booth-2.txt with sample contents (Multiple lines, one name in each line).
 
-####Fire MapReduce Job Execution
+#### Fire MapReduce Job Execution
 We are going to run our MapReduce Job as `hue` user.  Let us now change to the user `hue` by typing `su - hue` command pressing enter.  Now, you are the user `hue`.
 
 Now, we can use `hadoop jar` command to fire the job. Run the following command :
@@ -244,19 +244,19 @@ hadoop jar UtopiaVoteCount.jar /user/hue/VoteCountInput /user/hue/VoteCountOutpu
 
 Seeing the way the program is written, the above command means that the input files lie in /user/hue/VoteCountInput directory and the output will be produced in /user/hue/VoteCountOutput directory in HDFS.
 
-####Monitor MapReduce Job Execution
+#### Monitor MapReduce Job Execution
 You can monitor the progress of the triggered job using [Job Browser](http://localhost:8000/jobbrowser/).  If you wish, you could take a peek into the generated log files.
 
 ![Job Progress](images/tutorial-09/job_progress.png "Job Progress")
 
 ![Job Completed](images/tutorial-09/job_completed.png "Job Completed")
 
-####View Vote Count Results
+#### View Vote Count Results
 The final, consolidated vote count for each candidate can be found in a file present in the directory `/user/hue/VoteCountOutput`.  View this file using [File Browser](http://localhost:8000/filebrowser/) to know the number of votes each candidate got.
 
 ![Job Results](images/tutorial-09/job_results.png "Job Results")
 
 Assuming that you spent approximately an hour, including the setup and running of MapReduce job, you could be ready with the election results by 11 AM.  Then what? Party until 5 PM :)
 
-####Next Steps
+#### Next Steps
 Tweak the code and see what other use cases you can solve using Hadoop MapReduce.

--- a/Community/T10_Sentiment_Analysis_Workflow_Using_Oozie_MapReduce_and_Pig.md
+++ b/Community/T10_Sentiment_Analysis_Workflow_Using_Oozie_MapReduce_and_Pig.md
@@ -27,7 +27,7 @@ To follow the steps in this tutorial, your computer must have the following item
 ### Explanation of the Use Case
 A fictional use case is presented here, in order to enable you to easily understand the functionality and power of Oozie, without finding it overwhelming or boring. 
 
-####Sentiment Analysis using Twitter tweets
+#### Sentiment Analysis using Twitter tweets
 Given the tweets tweeted in a particular period, you are supposed to find the most popular actor among five candidates.  The names of the candidates are as follows:  
 1. Jaja  
 2. Jiji  
@@ -36,7 +36,7 @@ Given the tweets tweeted in a particular period, you are supposed to find the mo
 5. Jinjin  
 
 ### Instructions
-####Eclipse Project Setup
+#### Eclipse Project Setup
 1. Create an Eclipse Java Project with name `SentimentAnalysis`.
 2. Go to Project Properties window and in "Java Build Path" section, click on "Add External Jars"
 3. In the JAR Selection dialog, select the following jars from the extracted Hadoop tar.gz file.
@@ -47,7 +47,7 @@ Given the tweets tweeted in a particular period, you are supposed to find the mo
 
 ![Eclipse Build Path Settings](images/tutorial-09/eclipse_build_path_settings.png "Eclipse Build Path Settings")
 
-####Code the Mapper Class
+#### Code the Mapper Class
 In the eclipse project created above, create a new Java Class file with name `SentimentAnalysisMapper` and write the following code in it.  This will be the Mapper Class.
 
 ```java
@@ -88,7 +88,7 @@ public class SentimentAnalysisMapper extends MapReduceBase implements
 
 }
 ```
-####Code the Reducer Class
+#### Code the Reducer Class
 In the eclipse project created above, create a new Java Class file with name `SentimentAnalysisReducer` and write the following code in it.  This will be the Reducer Class.
 
 ```java
@@ -120,7 +120,7 @@ public class SentimentAnalysisReducer extends MapReduceBase implements
 
 }
 ```
-####Setting Java Version - Compiler Options
+#### Setting Java Version - Compiler Options
 Hortonworks Sandbox VM contains Java version 6.  So, we need to compile our classes using Java Version 6 in order to avoid Version Mismatch runtime exception.  To ensure compilation using Java Version 6, follow the below instructions.
 
 1. Right-click on the Java Project `SentimentAnalysis` and click on `Properties` menu option.
@@ -130,7 +130,7 @@ Hortonworks Sandbox VM contains Java version 6.  So, we need to compile our clas
 
 ![Eclipse Java Version Settings](images/tutorial-09/eclipse_java_version_settings.png "Eclipse Java Version Settings")
 
-####Creating a Java Archive (JAR) File
+#### Creating a Java Archive (JAR) File
 
 Now, let us export the Java Project to a JAR file.
 
@@ -140,7 +140,7 @@ Now, let us export the Java Project to a JAR file.
 4. Check if SentimentAnalysis.jar exists in ~/Desktop directory.'
 5. Upload SentimentAnalysis.jar to `/user/hue/` directory using [File Browser](http://localhost:8000/filebrowser/).
 
-####Creating a Pig script for Sorting
+#### Creating a Pig script for Sorting
 
 Now, let us create a Pig Script to sort candidates based on number of tweets.
 
@@ -152,7 +152,7 @@ maxTweets = ORDER tweetCounts BY tweetCount DESC;
 STORE maxTweets INTO '/user/hue/SentimentAnalysisFinalOutput/';
 ```
 
-####Creating Oozie Workflow
+#### Creating Oozie Workflow
 Now, let us create the Oozie workflow to execute our MapReduce job and then our Pig job.  
 
 1. Go to [Oozie Editor](http://127.0.0.1:8000/oozie) --> Workflows.
@@ -182,12 +182,12 @@ Archives :- No archives
  
  Similarly, edit the Pig block and specify `/user/hue/Sorting.pig` as "Script Name".
 
-####Monitor Oozie Job Execution
+#### Monitor Oozie Job Execution
 1. Place some sample tweets in any file within the `/user/hue/SentimentAnalysisInput` directory.
 2. Now, go back to [Oozie Editor](http://127.0.0.1:8000/oozie) -> Workflows and then to our Oozie workflow.
 3. Click on "Submit" link on the left side.
 4. You can monitor the Oozie job's progress in the same page, after submitting.
 ![Monitor Execution](images/tutorial-10/monitor_execution.png "Monitor Execution")
 
-####View Sentiment Analysis Results
+#### View Sentiment Analysis Results
 The final, consolidated tweet count for each candidate can be found in a file present in the directory `/user/hue/SentimentAnalysisFinalOutput`.  View this file using [File Browser](http://localhost:8000/filebrowser/) to know the number of tweets mentioning each candidate.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Hadoop Tutorials
+## Hadoop Tutorials
 
 This repo contains a set of tutorials for Hadoop designed to work inside or alongside the [Hortonworks Sandbox](http://hortonworks.com/products/hortonworks-sandbox/). Sandbox is a single-node Hadoop cluster that runs in a Virtual Machine (Virtual Box, VMWare, Hyper-V).
 
@@ -8,7 +8,7 @@ Please feel free to recommend edits to existing tutorials, and contribute your o
 
 Current tutorials are as follows:
 
-###Sandbox Tutorials (Embedded in Sandbox and tested with v2.0)
+### Sandbox Tutorials (Embedded in Sandbox and tested with v2.0)
 
 * [1 - Hello World - Using Sandbox with Hive and Pig](/Sandbox/T01_Hello_World_Using_Sandbox_with_Hive_and_Pig.md)
 * [2 - Data Processing with Pig - Processing Baseball Stats](/Sandbox/T02_Data_Processing_with_Pig.md)
@@ -25,7 +25,7 @@ Current tutorials are as follows:
 * [13 - Refining and Visualizing Sentiment Data](/Sandbox/T13_Refining_and_Visualizing_Sentiment_Data.md)
 * [14 - Analyzing Machine and Sensor Data](/Sandbox/T14_Analyzing_Machine_and_Sensor_Data.md)
 
-###Community Tutorials
+### Community Tutorials
 
 Feel free to contribute tutorials and help the community harness Hadoop!
 

--- a/Sandbox/T01_Hello_World_Using_Sandbox_with_Hive_and_Pig.md
+++ b/Sandbox/T01_Hello_World_Using_Sandbox_with_Hive_and_Pig.md
@@ -1,4 +1,4 @@
-##Tutorial 1: Hello World - Using the Hortonworks Sandbox with Hive and Pig
+## Tutorial 1: Hello World - Using the Hortonworks Sandbox with Hive and Pig
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T02_Data_Processing_with_Pig.md
+++ b/Sandbox/T02_Data_Processing_with_Pig.md
@@ -1,4 +1,4 @@
-##Tutorial 2: Data Processing with Pig - Processing Baseball Stats With Pig
+## Tutorial 2: Data Processing with Pig - Processing Baseball Stats With Pig
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T03_Data_Processing_with_Hive.md
+++ b/Sandbox/T03_Data_Processing_with_Hive.md
@@ -1,4 +1,4 @@
-##Tutorial 3: Data Processing With Hive - Processing Baseball Stats With Hive
+## Tutorial 3: Data Processing With Hive - Processing Baseball Stats With Hive
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T04_HCatalog_Basic_Pig_and_Hive.md
+++ b/Sandbox/T04_HCatalog_Basic_Pig_and_Hive.md
@@ -1,4 +1,4 @@
-##Tutorial 4: HCatalog, Basic Pig & Hive Commands
+## Tutorial 4: HCatalog, Basic Pig & Hive Commands
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T05_Using_Basic_Pig_Commands.md
+++ b/Sandbox/T05_Using_Basic_Pig_Commands.md
@@ -1,4 +1,4 @@
-##Tutorial 5: Using Basic Pig Commands
+## Tutorial 5: Using Basic Pig Commands
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T06_Loading_Data_into_Sandbox.md
+++ b/Sandbox/T06_Loading_Data_into_Sandbox.md
@@ -1,4 +1,4 @@
-##Tutorial 6: Loading Data into the Hortonworks Sandbox
+## Tutorial 6: Loading Data into the Hortonworks Sandbox
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T07_Installing_the_Hortonworks_ODBC_Driver_on_Windows_7.md
+++ b/Sandbox/T07_Installing_the_Hortonworks_ODBC_Driver_on_Windows_7.md
@@ -1,4 +1,4 @@
-##Tutorial 7: Installing and Configuring the Hortonworks ODBC driver on Windows 7
+## Tutorial 7: Installing and Configuring the Hortonworks ODBC driver on Windows 7
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T08_Using_Excel_2013_to_Access_Hadoop_data.md
+++ b/Sandbox/T08_Using_Excel_2013_to_Access_Hadoop_data.md
@@ -1,4 +1,4 @@
-##Tutorial 8: Using Excel 2013 to Access Sandbox Data
+## Tutorial 8: Using Excel 2013 to Access Sandbox Data
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T09_Using_Excel_2013_to_Analyze_Hadoop_data.md
+++ b/Sandbox/T09_Using_Excel_2013_to_Analyze_Hadoop_data.md
@@ -1,4 +1,4 @@
-##Tutorial 9: Using Excel 2013 to Analyze Sandbox Data
+## Tutorial 9: Using Excel 2013 to Analyze Sandbox Data
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T10_Visualizing_Website_Clickstream_Data.md
+++ b/Sandbox/T10_Visualizing_Website_Clickstream_Data.md
@@ -1,4 +1,4 @@
-##Tutorial 10: Visualizing Website Clickstream Data
+## Tutorial 10: Visualizing Website Clickstream Data
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T11_Installing_the_Hortonworks_ODBC_driver_on_Mac_OSX.md
+++ b/Sandbox/T11_Installing_the_Hortonworks_ODBC_driver_on_Mac_OSX.md
@@ -1,4 +1,4 @@
-##Tutorial 11: Installing and Configuring the Hortonworks ODBC driver on Mac OS X
+## Tutorial 11: Installing and Configuring the Hortonworks ODBC driver on Mac OS X
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T12_Refining_and_Visualizing_Server_Log_Data.md
+++ b/Sandbox/T12_Refining_and_Visualizing_Server_Log_Data.md
@@ -1,5 +1,5 @@
 
-##Tutorial 12: Refining and Visualizing Server Log Data
+## Tutorial 12: Refining and Visualizing Server Log Data
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T13_Refining_and_Visualizing_Sentiment_Data.md
+++ b/Sandbox/T13_Refining_and_Visualizing_Sentiment_Data.md
@@ -1,4 +1,4 @@
-##Tutorial 13: Refining and Visualizing Sentiment Data
+## Tutorial 13: Refining and Visualizing Sentiment Data
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T14_Analyzing_Machine_and_Sensor_Data.md
+++ b/Sandbox/T14_Analyzing_Machine_and_Sensor_Data.md
@@ -1,4 +1,4 @@
-##Tutorial 14: Analyzing Machine and Sensor Data
+## Tutorial 14: Analyzing Machine and Sensor Data
 
 **This tutorial is for HDP version 2.3 of the [Hortonworks Sandbox](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T15_Analyzing_Geolocation_Data.md
+++ b/Sandbox/T15_Analyzing_Geolocation_Data.md
@@ -1,4 +1,4 @@
-##Tutorial 15: Analyzing Geolocation Data
+## Tutorial 15: Analyzing Geolocation Data
 
 **This tutorial is from the [Hortonworks Sandbox 2.0](http://hortonworks.com/products/sandbox) - a single-node Hadoop cluster running in a virtual machine. [Download](http://hortonworks.com/products/sandbox) the Hortonworks Sandbox to run this and other tutorials in the series.**
 

--- a/Sandbox/T16_Searching with Solr.md
+++ b/Sandbox/T16_Searching with Solr.md
@@ -1,9 +1,9 @@
-###Overview
+### Overview
 In  this tutorial we will walk through how to use Apache Solr with Hadoop to index and search data stored on HDFS. It’s not meant as a general introduction to Solr.
   
 After working through this tutorial you will have Solr running on your Hortonworks Sandbox. You will also have a solrconfig and a schema which you can easily adapt to your own use cases. Also you will learn how to use Hadoop MapReduce to index files.    
   
-###Prerequisites
+### Prerequisites
   
   
 1. [Hortonworks HDP Sandbox 2.1](http://hortonworks.com/products/hortonworks-sandbox/)  
@@ -15,7 +15,7 @@ After working through this tutorial you will have Solr running on your Hortonwor
   
 Remarks: I was using VMware’s Fusion to run Sandbox. If you choose Virtualbox things should look the same beside the fact your VM will not have it’s own IP address but rather Solr listening on 127.0.0.1. For convenience I added sandbox as a host to my /etc/hosts file on my Mac. Apache Solr 4.7.2 is the officially by Hortonworks supported version as I’m writing this (May 2014).   
   
-###Steps
+### Steps
 
 Let’s get it started: Power-up the sandbox with at least 4GB main memory.
     

--- a/Sandbox/T17_HDPSecurity.md
+++ b/Sandbox/T17_HDPSecurity.md
@@ -1,8 +1,8 @@
-###Introduction
+### Introduction
 
 In this tutorial we will explore how you can use policies in HDP Security to protect your enterprise data lake and audit access by users to resources on HDFS, Hive and HBase from a centralized HDP Security Administration Console.
 
-###Prerequisite
+### Prerequisite
 
   - VirtualBox
   - Download [Hortonworks Sandbox + HDP Security](http://hortonassets.s3.amazonaws.com/2.1/hdpsecurity/XASecure3.5.000-on-HDP-2.1Sandbox.ova)
@@ -10,7 +10,7 @@ In this tutorial we will explore how you can use policies in HDP Security to pro
 After you download the VM, import the .ova file to VirtualBox and run the VM.
 
 
-###Login to HDP Security Administration Console 
+### Login to HDP Security Administration Console 
 
 Once the VM is running in VirtualBox, login to the HDP Security Administration console at [http://localhost:6080/](http://localhost:6080/) from your host machine. The username is `admin` and the password is `admin`
 
@@ -20,7 +20,7 @@ Once the VM is running in VirtualBox, login to the HDP Security Administration c
 As soon as you login, you should see list of repositories as shown below:
 ![](http://hortonassets.s3.amazonaws.com/tutorial/security/RepositoryList.png)
 
-###Review existing HDFS policies
+### Review existing HDFS policies
 
 Please click on `hadoopdev` link under HDFS section
 
@@ -29,7 +29,7 @@ Please click on `hadoopdev` link under HDFS section
 User can review policy details by a single click on the policy. The policy details will appear on the right.
 
 
-###Exercise HDFS access scenarios
+### Exercise HDFS access scenarios
 
 To validate the policy, please login into the sandbox using username `it1`. User `it1` belongs to the `IT` group.
 
@@ -73,7 +73,7 @@ Go to Policy Administrator tool, select the Audit tab from the top menu and then
 
 ![](http://hortonassets.s3.amazonaws.com/tutorial/security/HDFSAccessAuditGrantedUseCase.png)
 
-###Review Hive Policies
+### Review Hive Policies
 
 Click on PolicyManager section on the top menu, then click on `hivedev` link under HIVE section to view list of Hive Policies
 
@@ -81,7 +81,7 @@ Click on PolicyManager section on the top menu, then click on `hivedev` link und
 
 User can review policy details by a single click on the policy. The policy details will appear on the right.
 
-###Exercise Hive access scenarios
+### Exercise Hive access scenarios
 
 Run the `beeline` command to validate access for `mktg1` user to see if he can run 
 
@@ -133,14 +133,14 @@ Go to Policy Administrator tool and see its access (granted) being audited.
 ![](http://hortonassets.s3.amazonaws.com/tutorial/security/HIVEAccessAuditGrantedUseCase.png)
 
 
-###Review HBase Policies
+### Review HBase Policies
 Click on PolicyManager section on the top menu, then click on hbasedev link under HBASE section to view list of hbase Policies
 
 ![](http://hortonassets.s3.amazonaws.com/tutorial/security/HBasePolicyList.png)
 
 User can review policy details by a single click on the policy. The policy details will appear on the right.
 
-###Exercise HBase access scenarios
+### Exercise HBase access scenarios
 
 Ensure that the hbase service is running.
 ```bash
@@ -212,7 +212,7 @@ Go to Policy Administrator tool and see its access (granted) being audited.
 
 ![](http://hortonassets.s3.amazonaws.com/tutorial/security/HBaseAccessAuditGrantedV1.png)
 
-###Summary
+### Summary
 
 Hopefully by following this tutorial, you got a taste of the power and ease of securing your key enterprise resources using HDP Security.
 

--- a/Sandbox/partner/DG_Sandbox.md
+++ b/Sandbox/partner/DG_Sandbox.md
@@ -1,4 +1,4 @@
-###Introduction
+### Introduction
 
 Using DgSecure to discover and secure sensitive data is fairly straightforward and we
 will describe the process through a set of use cases in this document, which will include:
@@ -14,12 +14,12 @@ will describe the process through a set of use cases in this document, which wil
 3. Virtualization enabled on BIOS
 4. Browser: Chrome 25+, IE 9+ recommended. (Dataguise supports IE 10, however it is not supported in the Hortonworks Sandbox environment)
 
-###Step 1: Install a virtualization environment (3 Options)
+### Step 1: Install a virtualization environment (3 Options)
 
 1. Go to the following site to download one of the VM environements; http://hortonworks.com/products/hortonworks-sandbox/#install
 
 
-###Step 2: Download the Dataguise / Hortonworks Sandbox & License Key
+### Step 2: Download the Dataguise / Hortonworks Sandbox & License Key
 
  
 
@@ -36,7 +36,7 @@ browser can access.
 - (To access Hue, go to <http://sandbox.hortonworks.com:8000>)
 
 
-###Step 3: Apply DgSecure License & Sign In
+### Step 3: Apply DgSecure License & Sign In
 
 
 
@@ -68,7 +68,7 @@ sandbox.hortonworks.com)
 
 7. Click the browse button on the right in the install license section, and
 point to your downloaded license key and click OK, then click the install button.
-####*DgSecure is now ready to use for 30 days*
+#### *DgSecure is now ready to use for 30 days*
 
 ![2](http://dataguise.com/dgc/Sandbox/SandboxImages/Pic2.png)
 
@@ -76,7 +76,7 @@ point to your downloaded license key and click OK, then click the install button
 
 
 
-###Use Case 1: Define Custom Policy
+### Use Case 1: Define Custom Policy
 
 
 In this section we will be creating a custom policy that will be used
@@ -120,7 +120,7 @@ Policy is now created and ready to use.
 We are now ready to utilize the policy, and we will be running different
 tasks to explore the many features we have in our Hadoop product.
 
-###Use Case 2: Run Discovery Jobs 
+### Use Case 2: Run Discovery Jobs 
 
 First we will start with a discovery task against unstructured data,
 followed by a discovery task against structured data.
@@ -355,7 +355,7 @@ Detailed Results For Discovery Task Avro Files:
 
  
 
-###Use Case 3: Run Masking Jobs
+### Use Case 3: Run Masking Jobs
 
 
 **UNSTRUCTURED MASKING**
@@ -621,7 +621,7 @@ Detailed Results:
 
 ![37](http://dataguise.com/dgc/Sandbox/SandboxImages/Pic37.png)
 
-###Use Case 4: Run Encryption Jobs
+### Use Case 4: Run Encryption Jobs
 
 
 **Domain Definition**
@@ -832,7 +832,7 @@ Detailed Results:
 
 
 
-###Use Case 5: Run Bulk Decryption Jobs
+### Use Case 5: Run Bulk Decryption Jobs
 
  
 

--- a/Sandbox/start/UsingCommandlineToManageFilesOnHDFS.md
+++ b/Sandbox/start/UsingCommandlineToManageFilesOnHDFS.md
@@ -1,16 +1,16 @@
-#Using Commandline to manage files on HDFS
+# Using Commandline to manage files on HDFS
 
-##Preqequisites
+## Preqequisites
 A working HDP cluster - the easiest way to have a HDP cluster is to download the [Hortonworks Sandbox] [1].
 
-###Let's run some commands!
+### Let's run some commands!
 In this we are going to run 6 examples on how to handle with HDFS files & folders.
 
-####Step 1: Let's create a directory in HDFS, upload a file and list.
+#### Step 1: Let's create a directory in HDFS, upload a file and list.
 
 Let's look at the syntax first:
 
-#####hadoop fs -mkdir:
+##### hadoop fs -mkdir:
 -   It will take path uri's as argument and creates directory or directories.
 
 ```
@@ -21,7 +21,7 @@ Let's look at the syntax first:
             hadoop fs -mkdir hdfs://nn1.example.com/user/hadoop/dir
 ```
 
-#####hadoop fs -ls: 
+##### hadoop fs -ls: 
 
   - Lists the contents of a directory
   - For a file returns stats of a file
@@ -47,8 +47,8 @@ $ touch filename.txt
  
 ![enter image description here][3]
 
-####Step 2: Now, let's check how to find out space utilization in a HDFS dir.
-#####hadoop fs -du: 
+#### Step 2: Now, let's check how to find out space utilization in a HDFS dir.
+##### hadoop fs -du: 
 
  -  Displays sizes of files and directories contained in the given directory or the size of a file if its just a file.
   
@@ -61,11 +61,11 @@ $ touch filename.txt
 
 ![enter image description here][4]
 
-####Step 4: 
+#### Step 4: 
 Now let's see how to upload and download files from and to Hadoop Data File System(HDFS)
 Upload: ( we have already tried this earlier)
 
-#####hadoop fs -put:
+##### hadoop fs -put:
 -   Copy single src file, or multiple src files from local file system to the Hadoop data file system
 
 ```
@@ -89,9 +89,9 @@ hadoop fs -get:
 
 ![enter image description here][5]
 
-####Step 5: Let's look at quickly two advanced features.
+#### Step 5: Let's look at quickly two advanced features.
 
-#####hadoop fs -getmerge
+##### hadoop fs -getmerge
  
 -   Takes a source directory  files as input and concatenates files in src into the destination local file.
 
@@ -104,7 +104,7 @@ hadoop fs -get:
             addnl: can be set to enable adding a newline on end of each file
 ```
 
-#####hadoop distcp: 
+##### hadoop distcp: 
 
 -   Copy file or directories recursively
 -   It is a  tool used for large inter/intra-cluster copying

--- a/Sandbox/start/UsingHIVEforDataAnalysis.md
+++ b/Sandbox/start/UsingHIVEforDataAnalysis.md
@@ -1,4 +1,4 @@
-###Overview
+### Overview
 
 Hive is designed to enable easy data summarization and ad-hoc analysis of large volumes of data. It uses a query language called Hive-QL which is similar to SQL. 
 
@@ -12,11 +12,11 @@ In this tutorial, we will explore the following:
 6.  PARTITIONED a Table
 7.  Bucketing a Table
 
-###Prerequisites
+### Prerequisites
 
 A working HDP cluster - the easiest way to have a HDP cluster is to download the [Hortonworks Sandbox] [1]
 
-###Step 1.   Let's load a data file into a Hive table.
+### Step 1.   Let's load a data file into a Hive table.
 First of all, download data file from here [click here][2] and name the file as TwitterData.txt . You can copy the downloaded file into hdfs folder, /user/hadoop using hdfs fs -put command (see this [tutorial](http://hortonworks.com/hadoop-tutorial/using-commandline-manage-files-hdfs/)) or the Hue Interface. 
 
 As the file is small, you can simply open it, copy and create a local file in the sandbox manually as well.
@@ -62,10 +62,10 @@ Here is the log that you can refer for exact steps.
 
 Please run select * from this table to see the data.
 
-###Step 2.   Let's create a table using RCfile format
+### Step 2.   Let's create a table using RCfile format
 Record Columnar(RC) format determines how to store relational tables on distributed computer clusters. With this format, you can get the advantages of a columnar format over row format of a record. 
 
-#####Here is a sample Create RC file format table syntax:
+##### Here is a sample Create RC file format table syntax:
 ```sql
     CREATE TABLE TwitterExampleRCtable(
         tweetId INT, username BIGINT,
@@ -85,7 +85,7 @@ Here are the logs of the exact steps.
 
 ![](http://hortonassets.s3.amazonaws.com/tutorial/hive/Hive_HW_step_2.jpg)
 
-###Step 3.  Let's query the table we just created.
+### Step 3.  Let's query the table we just created.
 Let's find top 10 countries who tweeted most using TwitterExampleRCtable.
 ```sql
 Select profileLocation, COUNT(txt) as count1 FROM TwitterExampleRCtable GROUP BY profileLocation ORDER BY count1 desc limit 10;
@@ -94,7 +94,7 @@ Please see the folloiwng log and the results:
 ![](http://hortonassets.s3.amazonaws.com/tutorial/hive/Hive_Hw_step_3.1.jpg)
 ![](http://hortonassets.s3.amazonaws.com/tutorial/hive/Hive_HW_step3.2.jpg)
 
-###Step 4. Let's look at Managed tables vs External tables
+### Step 4. Let's look at Managed tables vs External tables
 Managed tables are created by default with CREATE TABLE statements, whereas External tables are used when you want your tables to point to data file in place. 
 
 Here is the syntax for creating these tables.
@@ -134,7 +134,7 @@ describe formatted ManagedExample;
 describe formatted ExternalExample;
 ```
 
-###Step 5. Hive ORC File format.
+### Step 5. Hive ORC File format.
 
 Optimized Row Columnar (ORC) File format is used as it further compresses data files. It could result in a small performance loss in writing, but there will be huge performance gain in reading. 
 
@@ -152,7 +152,7 @@ Let's try it out. Please see that the table is stored as ORC.
     STORED AS ORC tblproperties ("orc.compress"="GLIB");
 ```
 
-###Step 6. Let's create a PARTITIONED Table and load data into.
+### Step 6. Let's create a PARTITIONED Table and load data into.
 Partitions are  horizontal slices of data which allow large sets of data to be segmented into more manageable blocks.
 Here is the sample syntax to create a partitioned table and load data into partitions.
 
@@ -169,7 +169,7 @@ Here is the log from creating a table with ORC file format and a Partitioned tab
 
 ![](http://hortonassets.s3.amazonaws.com/tutorial/hive/Hive_HW_step4.2.jpg
 )
-###Step 7. Let's create a table with Buckets.
+### Step 7. Let's create a table with Buckets.
 
 Bucketing is a technique that allows to cluster or segment large sets of data to optimize query performance.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
